### PR TITLE
Fix blip issues and increase default blip refresh rate

### DIFF
--- a/client/framework/ox_core.lua
+++ b/client/framework/ox_core.lua
@@ -45,7 +45,7 @@ end
 function ox.getOfficerData()
     if player and player.charId then
         local group, grade, title = ox.getGroupInfo()
-        localOfficer.stateId = player.get("stateId")
+        localOfficer.stateId = player.stateId
         localOfficer.firstName = player.get("firstName")
         localOfficer.lastName = player.get("lastName")
         localOfficer.group = group

--- a/client/main.lua
+++ b/client/main.lua
@@ -328,36 +328,36 @@ RegisterNetEvent('ox_mdt:refreshUnits', function(data)
     })
 end)
 
+AddTextEntry('BLIP_OTHPLYR', 'Units')
 local blips = {}
 
 ---@param data Officer[]
 RegisterNetEvent('ox_mdt:updateOfficerPositions', function(data)
-    if not hasLoadedUi then return end
-
     for i = 1, #data do
         local officer = data[i]
 
-        if officer.stateId ~= player.stateid then
+        if officer.stateId ~= player.stateId then
             local blip = blips[officer.stateId]
 
             if not blip then
                 local name = ('police:%s'):format(officer.stateId)
-                blip = AddBlipForCoord(officer.position[2], officer.position[1], officer.position[3])
+                blip = AddBlipForCoord(officer.position[1], officer.position[2], officer.position[3])
                 blips[officer.stateId] = blip
 
                 SetBlipSprite(blip, 1)
                 SetBlipDisplay(blip, 3)
                 SetBlipColour(blip, 42)
-                ShowFriendIndicatorOnBlip(blip, true)
-                AddTextEntry(name, ('%s %s (%s)'):format(officer.firstName, officer.lastName, officer.callSign))
+                AddTextEntry(name, officer.callSign and ('%s %s (%s)'):format(officer.firstName, officer.lastName, officer.callSign) or ('%s %s'):format(officer.firstName, officer.lastName))
                 BeginTextCommandSetBlipName(name)
                 EndTextCommandSetBlipName(blip)
                 SetBlipCategory(blip, 7)
             else
-                SetBlipCoords(blip, officer.position[2], officer.position[1], officer.position[3])
+                SetBlipCoords(blip, officer.position[1], officer.position[2], officer.position[3])
             end
         end
     end
+
+    if not hasLoadedUi then return end
 
     SendNUIMessage({
         action = 'updateOfficerPositions',

--- a/server/calls.lua
+++ b/server/calls.lua
@@ -66,8 +66,7 @@ Citizen.SetTimeout(7500, function()
         updateCallCoords(id, {coords.x + (multiplier*100), coords.y + (multiplier*100)})
         multiplier += 1
     end, 1500)
-end)
-]]
+end)]]
 
 ---@param source number
 ---@param data 'active' | 'completed'

--- a/server/framework/ox_core.lua
+++ b/server/framework/ox_core.lua
@@ -41,7 +41,7 @@ local function addOfficer(playerId)
     local group, grade = player.getGroup(config.policeGroups)
 
     if group and grade then
-        officers.add(playerId, player.firstName, player.lastName, player.stateId, group, grade)
+        officers.add(playerId, player.get('firstName'), player.get('lastName'), player.stateId, group, grade)
     end
 end
 

--- a/server/officers.lua
+++ b/server/officers.lua
@@ -25,7 +25,7 @@ SetInterval(function()
 
     triggerOfficerEvent('ox_mdt:updateOfficerPositions', officersArray)
     table.wipe(officersArray)
-end, math.max(500, GetConvarInt('mdt:positionRefreshInterval', 5000)))
+end, math.max(500, GetConvarInt('mdt:positionRefreshInterval', 2500)))
 
 ---@param playerId number
 ---@param firstName string


### PR DESCRIPTION
- fix blip location being flipped
- fix call waypoint location being flipped
- fixed "nil nil (nil)" blips
- Renamed category from "Other players" to "Units"
- Show blips on map regardless of the MDT being opened before.
- Removed friend indicator as it is intended for showing Social Club friends in Online.

I will also look into adding [blips attached to the entity](https://docs.fivem.net/natives/?_0x5CDE92C702A8FCE7) when the officer is close instead of just the coordinates, which could increase performance and decrease network activity, like in [Renewed-Dutyblips](https://github.com/Renewed-Scripts/Renewed-Dutyblips)